### PR TITLE
add configuration file for data folders and iiif server address

### DIFF
--- a/aidaLocal/config.ini
+++ b/aidaLocal/config.ini
@@ -1,0 +1,7 @@
+images_dir = data/images
+annotations_dir = data/annotations
+
+[IIIF]
+hostname = localhost
+port = 8182
+https = false

--- a/aidaLocal/package.json
+++ b/aidaLocal/package.json
@@ -7,6 +7,7 @@
     "chalk": "^2.4.2",
     "connect-history-api-fallback": "^1.6.0",
     "express": "^4.17.1",
-    "ip": "^1.1.5"
+    "ip": "^1.1.5",
+    "ini": "^1.3.5"
   }
 }

--- a/src/store/modules/image/mutations.js
+++ b/src/store/modules/image/mutations.js
@@ -1,5 +1,6 @@
 import Vue from 'vue'
 import openseadragon from 'openseadragon'
+import axios from 'axios'
 
 export default {
   setProjectImageName: (state, projectImageName) => {
@@ -68,10 +69,13 @@ export default {
     // Add the image to the OSD viewer.
     // Require different API method calls for tiled/simple images.
     if (payload.fileType === 'tiled') {
-      state.OSDviewer.addTiledImage({
-        tileSource: 'http://localhost:8182/iiif/2/' + encodeURIComponent(payload.source) + '/info.json',
-        opacity: payload.opacity
-      })
+      axios.get(location.origin + '/iiif')
+        .then((response) => {
+          state.OSDviewer.addTiledImage({
+            tileSource: new URL(encodeURIComponent(payload.source) + '/info.json', response.data.toString()).toString(),
+            opacity: payload.opacity
+          })
+        })
     } else if (payload.fileType === 'dzi') {
       state.OSDviewer.addTiledImage({
         tileSource: payload.source,


### PR DESCRIPTION
The paths of the images and annotations folders and the iiif server address are now configurable through the config.ini file. Both relative and absolute paths are supported.
Also, it is now possible to launch aidaLocal from any working directory.